### PR TITLE
Second claim

### DIFF
--- a/components/Alert.tsx
+++ b/components/Alert.tsx
@@ -27,7 +27,7 @@ const Alert = ({ shouldShow, alertBody }: AlertProps) => {
                         </button>
                         <VStack gapSize={StackGapSize.Medium}>
                             <p className={styles.title}>Are you sure?</p>
-                            <p>You haven't yet reached the maximum possible earned ECOx based on your payout schedule.</p>
+                            <p>You haven&apos;t yet reached the maximum possible earned ECOx based on your payout schedule.</p>
                             <div />
                             <HStack>
                                 <Button title="Cancel" onClick={alertBody.primaryButtonHandler} />

--- a/components/Alert.tsx
+++ b/components/Alert.tsx
@@ -1,0 +1,64 @@
+import { createContext } from "react";
+import styles from "css/modules/alert.module.scss";
+import VStack from "./vstack";
+import HStack, { StackGapSize } from "./hstack";
+import classNames from "classnames";
+import Button from "./button";
+
+type AlertProps = {
+    shouldShow: boolean;
+    alertBody: AlertType;
+}
+
+const Alert = ({ shouldShow, alertBody }: AlertProps) => {
+
+    return (
+        <AlertContext.Consumer>
+            {context => (
+                <div className={classNames(
+                    styles.alert,
+                    shouldShow ? styles["alert-isVisible"] : undefined)}>
+                    <div className={styles.container}>
+                        <button className={styles.alertClose} onClick={() => context.setShouldShow(false)}>
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M18 6L12 12L18 18" stroke="black" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                                <path d="M6 6L12 12L6 18" stroke="black" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                        </button>
+                        <VStack gapSize={StackGapSize.Medium}>
+                            <p className={styles.title}>Are you sure?</p>
+                            <p>You haven't yet reached the maximum possible earned ECOx based on your payout schedule.</p>
+                            <div />
+                            <HStack>
+                                <Button title="Cancel" onClick={alertBody.primaryButtonHandler} />
+                                <Button title="Yes, continue claim" secondary onClick={alertBody.secondaryButtonHandler} />
+                            </HStack>
+                        </VStack>
+                    </div>
+                </div>
+            )}
+        </AlertContext.Consumer>
+    )
+}
+
+export const AlertContext = createContext<{
+    shouldShow: boolean;
+    setShouldShow: (_: boolean) => void;
+    alertBody: AlertType;
+    setAlert: (_: AlertType) => void;
+}>({
+    shouldShow: false,
+    setShouldShow: () => { },
+    alertBody: {
+        primaryButtonHandler: () => {},
+        secondaryButtonHandler: () => {}
+    },
+    setAlert: () => { }
+})
+
+export type AlertType = {
+    primaryButtonHandler: () => void;
+    secondaryButtonHandler: () => void;
+}
+
+export default Alert;

--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -65,7 +65,7 @@ const ClaimDetails = ({ claimingEndsAt, claim, hasAdditionalClaims, onClaimButto
                                         `text-size-small`,
                                         styles.countdownLabel
                                     )}>Claim Window ends in: {days}d, {hours}h, {minutes}m, {seconds}s</p>
-                                    <p className="text-size-small">You’ll be eligible to claim more ECO and ECOx starting 30 days after you complete this claim process. <a href="https://eco.org/articles/eco-ecox-overview#community-claim" rel="noreferrer" target="_blank" className="text-color-medium">Want to know more?</a>.
+                                    <p className="text-size-small">You’ll be eligible to claim more ECO and ECOx starting 30 days after you complete this claim process. <a href="https://eco.org/articles/eco-ecox-overview#community-claim" rel="noreferrer" target="_blank" className="text-color-medium">Want to know more?</a>
                                     </p>
                                 </>
                             )

--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -4,13 +4,11 @@ import classNames from "classnames";
 import styles from "css/modules/claim-details.module.scss";
 import { BigNumber, utils } from "ethers";
 import { VerifiedClaim } from "hooks/VerifiedClaims";
-import { upperFirst } from "lodash";
 import { useEcoClaim } from "providers/EcoClaim";
 import Countdown from "react-countdown";
 import Button from "./button";
 import CurrencyItem from "./CurrencyItem";
 import HStack, { StackGapSize } from "./hstack";
-import TextLoader from "./TextLoader";
 import VStack from "./vstack";
 
 type ClaimDetailsProps = {
@@ -42,7 +40,7 @@ const ClaimDetails = ({ claimingEndsAt, claim, hasAdditionalClaims, onClaimButto
         <div className={styles.claimDetails}>
             <HStack align="end">
                 <VStack style={{ flex: 1 }} gapSize={StackGapSize.Small}>
-                    <p className="sectionSubtitle">Available to claim today</p>
+                    <p className="sectionSubtitle">First Claim</p>
                     <CurrencyItem amount={getEco()} currency="eco" message="The points are the point" />
                     <CurrencyItem amount={getEcoX()} currency="ecox" message="We all win together" />
                 </VStack>

--- a/components/ClaimDetailsHeaderClaimed.tsx
+++ b/components/ClaimDetailsHeaderClaimed.tsx
@@ -12,18 +12,18 @@ import LinkButton from "./LinkButton";
 import VStack from "./vstack";
 
 type ClaimDetailsHeaderClaimedProps = {
-    verifiedClaims: VerifiedClaim[];
+    eligibleClaims: VerifiedClaim[];
     selectedClaim: VerifiedClaim;
     onBackButtonClick: () => void;
 }
 
 
-const ClaimDetailsHeaderClaimed = ({ verifiedClaims, selectedClaim, onBackButtonClick }: ClaimDetailsHeaderClaimedProps) => {
+const ClaimDetailsHeaderClaimed = ({ eligibleClaims, selectedClaim, onBackButtonClick }: ClaimDetailsHeaderClaimedProps) => {
 
     return (
         <>
             <VStack>
-                {verifiedClaims.length > 1 &&
+                {eligibleClaims.length > 1 &&
                     <div>
                         <LinkButton isBounded onClick={onBackButtonClick} text="Back" color="gray" small leadingIcon={
                             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -34,23 +34,45 @@ const ClaimDetailsHeaderClaimed = ({ verifiedClaims, selectedClaim, onBackButton
                         } />
                     </div>
                 }
-                <Copy>
-                    <p className="text-size-xlarge text-color-normal font-romana">
-                        <span className="text-color-medium"> {upperFirst(selectedClaim.app)}{" "}({shortAddress(selectedClaim.userid)}),</span>
-                        <br />
-                        <span className="text-color-normal">you&apos;ve completed your claim. But there&apos;s still more to come...</span>
-                    </p>
-                    <p>It pays to be early. But it also pays to be patient. You&apos;ll be eligible to claim more ECOx depending on how long you wait. Until then, it&apos;s time to build. To learn more about how to vote with your tokens, and how else you can use them, visit <a href="https://eco.org/" rel="noreferrer" target="_blank">eco.org</a> or drop into the <a href="http://discord.eco.org" rel="noreferrer" target="_blank">Eco Discord</a>.</p>
-                </Copy>
+                {selectedClaim.tokenRelease ? (
+                    <Copy>
+                        <p className="text-size-xlarge text-color-normal font-romana">
+                            <span className="text-color-medium"> {upperFirst(selectedClaim.app)}{" "}({shortAddress(selectedClaim.userid)}),</span>
+                            <br />
+                            <span className="text-color-normal">your claim is complete.</span>
+                        </p>
+                        <p>It&apos;s time to build. To learn more about how to vote with your tokens, and how else you can use them, visit <a href="https://eco.org/" rel="noreferrer" target="_blank">eco.org</a> or drop into the <a href="http://discord.eco.org" rel="noreferrer" target="_blank">Eco Discord</a>.</p>
+                    </Copy>
+                ) : (
+                    <Copy>
+                        <p className="text-size-xlarge text-color-normal font-romana">
+                            <span className="text-color-medium"> {upperFirst(selectedClaim.app)}{" "}({shortAddress(selectedClaim.userid)}),</span>
+                            <br />
+                            <span className="text-color-normal">you&apos;ve completed your first claim. But there&apos;s still more to come...</span>
+                        </p>
+                        <p>It pays to be early. But it also pays to be patient. You&apos;ll be eligible to claim more ECOx depending on how long you wait. Until then, it&apos;s time to build. To learn more about how to vote with your tokens, and how else you can use them, visit <a href="https://eco.org/" rel="noreferrer" target="_blank">eco.org</a> or drop into the <a href="http://discord.eco.org" rel="noreferrer" target="_blank">Eco Discord</a>.</p>
+                    </Copy>
+                )
+                }
             </VStack>
             <VStack gapSize={StackGapSize.None}>
-                <p className="sectionSubtitle text-color-medium">Claimed on {new Date(selectedClaim.tokenClaim.claimTime.toNumber() *
+                <p className="sectionSubtitle text-color-medium">First claim on {new Date(selectedClaim.tokenClaim.claimTime.toNumber() *
                     1000).toLocaleDateString('en-US')}</p>
                 <CurrencyItem amount={utils.formatUnits(selectedClaim.tokenClaim.amountEco)} currency="eco" />
                 <CurrencyItem amount={utils.formatUnits(selectedClaim.tokenClaim.amountEcox)} currency="ecox" />
             </VStack>
 
-            {verifiedClaims.length > 1 &&
+            {selectedClaim.tokenRelease ? (
+                <VStack gapSize={StackGapSize.None}>
+                    <p className="sectionSubtitle text-color-medium">Second claim on {new Date(selectedClaim.tokenRelease.claimTime.toNumber() *
+                        1000).toLocaleDateString('en-US')}</p>
+                    <CurrencyItem amount={utils.formatUnits(selectedClaim.tokenRelease.amountEco)} currency="eco" />
+                    <CurrencyItem amount={utils.formatUnits(selectedClaim.tokenRelease.amountEcox)} currency="ecox" />
+                </VStack>
+            ) : <></>
+            }
+
+            {eligibleClaims.length > 1 &&
                 <div>
                     <Button small title="Make another claim" secondary showArrow onClick={onBackButtonClick} />
                 </div>

--- a/components/ClaimDetailsHeaderClaimed.tsx
+++ b/components/ClaimDetailsHeaderClaimed.tsx
@@ -1,5 +1,5 @@
 import { utils } from "ethers";
-import { VerifiedClaim } from "hooks/VerifiedClaims";
+import { ClaimState, VerifiedClaim } from "hooks/VerifiedClaims";
 import { shortAddress } from "pages/claim";
 import Button from "./button";
 import Callout from "./callout";
@@ -48,9 +48,10 @@ const ClaimDetailsHeaderClaimed = ({ eligibleClaims, selectedClaim, onBackButton
                         <p className="text-size-xlarge text-color-normal font-romana">
                             <span className="text-color-medium"> {upperFirst(selectedClaim.app)}{" "}({shortAddress(selectedClaim.userid)}),</span>
                             <br />
-                            <span className="text-color-normal">you&apos;ve completed your first claim. But there&apos;s still more to come...</span>
+                            <span className="text-color-normal">{selectedClaim.claimState === ClaimState.ReadyForSecondClaim ? "Congratulations, you're eligible to claim!" : "you've completed your first claim. But there's still more to come..."}</span>
                         </p>
-                        <p>It pays to be early. But it also pays to be patient. You&apos;ll be eligible to claim more ECOx depending on how long you wait. Until then, it&apos;s time to build. To learn more about how to vote with your tokens, and how else you can use them, visit <a href="https://eco.org/" rel="noreferrer" target="_blank">eco.org</a> or drop into the <a href="http://discord.eco.org" rel="noreferrer" target="_blank">Eco Discord</a>.</p>
+                        <p>It pays to be early. But it also pays to be patient. {selectedClaim.claimState === ClaimState.ReadyForSecondClaim ? "You're eligible to make your final claim now, but will be able " : "You'll be eligible "}to claim more ECOx depending on how long you wait.</p>
+                        <p>You can transfer claimed ECO and ECOx to your connected wallet. Note that there will be a gas cost for the claim.</p>
                     </Copy>
                 )
                 }

--- a/components/ClaimDetailsHeaderClaimed.tsx
+++ b/components/ClaimDetailsHeaderClaimed.tsx
@@ -71,12 +71,6 @@ const ClaimDetailsHeaderClaimed = ({ eligibleClaims, selectedClaim, onBackButton
                 </VStack>
             ) : <></>
             }
-
-            {eligibleClaims.length > 1 &&
-                <div>
-                    <Button small title="Make another claim" secondary showArrow onClick={onBackButtonClick} />
-                </div>
-            }
         </>
     )
 }

--- a/components/ClaimDetailsHeaderUnclaimed.tsx
+++ b/components/ClaimDetailsHeaderUnclaimed.tsx
@@ -7,16 +7,16 @@ import VStack from "./vstack";
 
 
 type ClaimDetailsHeaderUnclaimedProps = {
-    verifiedClaims: VerifiedClaim[];
+    eligibleClaims: VerifiedClaim[];
     onBackButtonClick: () => void;
     selectedClaim: VerifiedClaim;
 }
 
-const ClaimDetailsHeaderUnclaimed = ({ verifiedClaims, onBackButtonClick, selectedClaim }: ClaimDetailsHeaderUnclaimedProps) => {
+const ClaimDetailsHeaderUnclaimed = ({ eligibleClaims, onBackButtonClick, selectedClaim }: ClaimDetailsHeaderUnclaimedProps) => {
     return (
         <VStack>
             {
-                verifiedClaims.length > 1 &&
+                eligibleClaims.length > 1 &&
                 <div>
                     <LinkButton isBounded onClick={onBackButtonClick} text="Back" color="gray" small leadingIcon={
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/components/Pill.tsx
+++ b/components/Pill.tsx
@@ -1,0 +1,14 @@
+import styles from "css/modules/pill.module.scss";
+import { ReactNode } from "react";
+
+const Pill = ({
+    children
+}: { children: ReactNode }) => {
+    return (
+        <div className={styles.pill}>
+            {children}
+        </div>
+    )
+}
+
+export default Pill;

--- a/components/Projection.tsx
+++ b/components/Projection.tsx
@@ -32,7 +32,7 @@ const Projection = ({ claim, onClaimButtonClick, isClaimPending }: ProjectionPro
     const [wrapperHeight, setWrapperHeight] = useState(0);
     const sliderRef = useRef<HTMLDivElement>(null);
     const xRef = useRef(x);
-    const [showDetails, setShowDetails] = useState(false);
+    const [showDetails, setShowDetails] = useState(true);
     const measureRef = useRef<HTMLDivElement>(null);
 
     const ecoClaim = useEcoClaim();

--- a/components/Projection.tsx
+++ b/components/Projection.tsx
@@ -294,7 +294,7 @@ const Projection = ({ claim, onClaimButtonClick, isClaimPending }: ProjectionPro
                             {!claim.tokenClaim ?
                                 <> 30 days after you complete your first claim, you’ll be able to claim another {getEco()} ECO. And you’ll also be able to claim more ECOx, although the longer you wait, the more you’ll get. <a onClick={handleLearnMoreClick} style={{ cursor: "pointer" }}>Want to learn more?</a></>
                                 : currentCliffX ?
-                                    <>You're ready to claim another {getEco()} ECO. And you’ll also be able to claim more ECOx, although the longer you wait, the more you’ll get. <a onClick={handleLearnMoreClick} style={{ cursor: "pointer" }}>Want to learn more?</a></> :
+                                    <>You&apos;re ready to claim another {getEco()} ECO. And you’ll also be able to claim more ECOx, although the longer you wait, the more you’ll get. <a onClick={handleLearnMoreClick} style={{ cursor: "pointer" }}>Want to learn more?</a></> :
                                     <>In 30 days, you’ll be able to claim another {getEco()} ECO. And you’ll also be able to claim more ECOx, although the longer you wait, the more you’ll get. <a onClick={handleLearnMoreClick} style={{ cursor: "pointer" }}>Want to learn more?</a></>
                             }
                         </p>

--- a/components/Projection.tsx
+++ b/components/Projection.tsx
@@ -251,10 +251,6 @@ const Projection = ({ claim, onClaimButtonClick, isClaimPending }: ProjectionPro
 
     const { setShouldShow } = useContext(HelpOverlayContext);
 
-    const handleLearnMoreClick = () => {
-        setShouldShow(true);
-    }
-
     if (claim.tokenRelease) {
         return <></>;
     }
@@ -292,11 +288,12 @@ const Projection = ({ claim, onClaimButtonClick, isClaimPending }: ProjectionPro
                     <VStack gapSize={StackGapSize.Large}>
                         <p className="text-size-small text-color-medium">
                             {!claim.tokenClaim ?
-                                <> 30 days after you complete your first claim, you’ll be able to claim another {getEco()} ECO. And you’ll also be able to claim more ECOx, although the longer you wait, the more you’ll get. <a onClick={handleLearnMoreClick} style={{ cursor: "pointer" }}>Want to learn more?</a></>
+                                `30 days after you complete your first claim, you’ll be able to claim another ${getEco()} ECO. And you’ll also be able to claim more ECOx, although the longer you wait, the more you’ll get. `
                                 : currentCliffX ?
-                                    <>You&apos;re ready to claim another {getEco()} ECO. And you’ll also be able to claim more ECOx, although the longer you wait, the more you’ll get. <a onClick={handleLearnMoreClick} style={{ cursor: "pointer" }}>Want to learn more?</a></> :
-                                    <>In 30 days, you’ll be able to claim another {getEco()} ECO. And you’ll also be able to claim more ECOx, although the longer you wait, the more you’ll get. <a onClick={handleLearnMoreClick} style={{ cursor: "pointer" }}>Want to learn more?</a></>
+                                    `You’re ready to claim another ${getEco()} ECO. And you’ll also be able to claim more ECOx, although the longer you wait, the more you’ll get. ` :
+                                    `In 30 days, you’ll be able to claim another ${getEco()} ECO. And you’ll also be able to claim more ECOx, although the longer you wait, the more you’ll get. `
                             }
+                            <a href="https://eco.org/articles/eco-ecox-overview#community-claim" rel="noreferrer" target="_blank" style={{ cursor: "pointer" }}>Want to learn more?</a>
                         </p>
                         <div className={styles.chartWrapper}>
                             <div className={styles.projectionChart}>

--- a/css/modules/alert.module.scss
+++ b/css/modules/alert.module.scss
@@ -1,0 +1,89 @@
+.alert {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    background: rgba(0, 0, 0, .5);
+    z-index: 999;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--anim-curve-ease-out) var(--anim-duration-long);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    &-isVisible {
+        opacity: 1;
+        pointer-events: all;
+        
+        .container {
+            opacity: 1 !important;
+            transform: translateY(0) !important;
+        }
+    }
+
+    .container {
+        background: var(--color-background);
+        overflow-y: auto;
+        border-radius: var(--border-radius-default);
+        display: flex;
+        flex-direction: column;
+        opacity: 0;
+        transform: translateY(10px);
+        transition: all var(--anim-curve-ease-out) var(--anim-duration-long);
+        transition-delay: 0.1s;
+        max-width: 50vw;
+        margin-left: auto;
+        margin-right: auto;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, .2);
+        padding: var(--space-large);
+        min-width: 300px;
+    }
+
+    .title {
+        font-weight: 600;
+    }
+
+    .alertClose {
+        position: absolute;
+        top: calc((var(--min-mobile-tap-size) - var(--space-large)) / 2);
+        right: calc((var(--min-mobile-tap-size) - var(--space-large)) / 2);
+        width: var(--min-mobile-tap-size);
+        height: var(--min-mobile-tap-size);
+        appearance: none;
+        border: none;
+        border-radius: 50%;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: none;
+        padding: 0;
+        margin: 0;
+    
+        &:hover {
+            opacity: 0.7;
+        }
+    
+        &:before {
+            position: absolute;
+            width: var(--space-large);
+            height: var(--space-large);
+            background-color: red;
+            content: "";
+            border-radius: 50%;
+            background-color: var(--color-background-shade);
+            z-index: 1;
+        }
+    
+        svg {
+            position: relative;
+            z-index: 2;
+    
+            path {
+                stroke: var(--color-text-light);
+            }
+        }
+    }
+}

--- a/css/modules/header.module.scss
+++ b/css/modules/header.module.scss
@@ -5,8 +5,27 @@
   display: flex;
   justify-content: flex-end;
   z-index: 999;
-
   padding: var(--space-large);
+  border-bottom-left-radius: var(--border-radius-default);
+
+  backdrop-filter: blur(8px);
+
+  &:after {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: 0;
+    background-color: var(--color-background);
+    content: "";
+    z-index: 0;
+    border-bottom-left-radius: var(--border-radius-default);
+    opacity: 0.8;
+  }
+
+  > * {
+    z-index: 1;
+  }
 
   ul {
     list-style: none;

--- a/css/modules/home.module.scss
+++ b/css/modules/home.module.scss
@@ -39,7 +39,7 @@
         }
     }
 
-    &.isClaimed {
+    &.actionAvailable {
         background-color: transparent;
         border: 1px solid var(--color-background-shade);
     }

--- a/css/modules/pill.module.scss
+++ b/css/modules/pill.module.scss
@@ -1,0 +1,9 @@
+.pill {
+    font-size: var(--font-size-xsmall);
+    padding: 2px 4px;
+    background-color: rgba(0, 0, 0, .1);
+    display: inline-block;
+    border-radius: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}

--- a/css/modules/projection.module.scss
+++ b/css/modules/projection.module.scss
@@ -138,6 +138,18 @@
     }
 }
 
+.projectionChartCurrentIndicator {
+    background-color: transparent !important;
+    top: -24px !important;
+    background: linear-gradient(0deg, rgba(0, 0, 0, .3) 0%, rgba(0, 0, 0, .3) 6px, transparent 4px);
+    background-size: 1.5px 12px;
+    background-repeat: repeat-y;
+
+    label {
+        background-color: var(--color-text-medium) !important;
+    }
+}
+
 .projectionChartOverlay {
     position: absolute;
     left: 0;

--- a/css/modules/projection.module.scss
+++ b/css/modules/projection.module.scss
@@ -74,7 +74,7 @@
     border-radius: 50%;
     user-select: none;
     cursor: ew-resize;
-    z-index: 2;
+    z-index: 8;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -90,9 +90,9 @@
     left: 0;
     top: 0;
     bottom: 0;
+    z-index: 4;
     background-color: var(--color-accent);
     z-index: 1;
-    //border-radius: 999em;
     opacity: 0;
 }
 
@@ -155,6 +155,17 @@
     left: 0;
     right: 0;
     top: 0;
+    z-index: 6;
+
+    &:before {
+        position: absolute;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        width: 25%;
+        content: "";
+        background: linear-gradient(90deg, transparent, var(--color-background));
+    }
 
     div {
         position: absolute;

--- a/hooks/VerifiedClaims.tsx
+++ b/hooks/VerifiedClaims.tsx
@@ -1,9 +1,11 @@
 import { gql, useQuery } from "@apollo/client";
 import { BigNumber } from "ethers";
+import { useEcoClaim } from "providers/EcoClaim";
 
 import productionPointsDB from "../assets/production/points.json";
 import stagingPointsDB from "../assets/staging/points.json";
 import developmentPointsDB from "../assets/development/points.json";
+import { useEffect, useState } from "react";
 
 let pointsDB;
 switch (process.env.NEXT_PUBLIC_ENVIRONMENT) {
@@ -26,24 +28,44 @@ export type TokenClaim = {
     claimTime: BigNumber;
 }
 
+export type TokenRelease = {
+    amountEco: BigNumber;
+    amountEcox: BigNumber;
+    recipient: string;
+    claimTime: BigNumber;
+    gasPayer: string;
+    feeAmount: string;
+}
+
+export enum ClaimState {
+    Unclaimed,
+    NotReadyForSecondClaim,
+    ReadyForSecondClaim,
+    FullyClaimed
+}
+
 export type VerifiedClaim = {
     app: string;
     userid: string;
     points: BigNumber;
     recipient: string;
     verifiers: { address: string, revocable: boolean }[];
+    claimState: ClaimState;
     nft: {
         tokenID: number;
         tokenURI: string;
     } | null;
     tokenClaim: TokenClaim | null;
+    tokenRelease: TokenRelease | null;
 }
 
 const points: { [claim: string]: string } = pointsDB;
 
 // returns a list of your claims that are eligible to, or have already redeem points
 
-export const useVerifiedClaims = (address: string | null, trustedVerifier: string | null): VerifiedClaim[] => {
+export const useVerifiedClaims = (address: string | null): VerifiedClaim[][] => {
+
+    const ecoClaim = useEcoClaim();
 
     const { data, loading, error, startPolling } = useQuery(VERIFIED_CLAIMS, {
         variables: {
@@ -53,37 +75,81 @@ export const useVerifiedClaims = (address: string | null, trustedVerifier: strin
     });
     startPolling(5000);
 
-    let verifiedClaims = [];
+    const [verifiedClaims, setVerifiedClaims] = useState<VerifiedClaim[][]>([[],[],[],[],[]]);
+
+    useEffect(() => {
+        const parseVerifiedClaims = () => {
+            // all eligible claims regardless of state
+            let eligible: VerifiedClaim[] = [];
+            // eligible claims separated by state
+            let unclaimed: VerifiedClaim[] = [];
+            let notReadyForSecondClaim: VerifiedClaim[] = [];
+            let readyForSecondClaim: VerifiedClaim[] = [];
+            let fullyClaimed: VerifiedClaim[] = [];
+
+            eligible = data.verifiedClaims.reduce((eligibleClaims: VerifiedClaim[], subgraphVerifiedClaim) => {
+                // no points, not claimable
+                // not verified by the trusted verifier, not claimable
+                const pts = BigNumber.from(points[subgraphVerifiedClaim.id] || 0);
+    
+                if (pts.gt(0) && subgraphVerifiedClaim.verifiers.find((verifier) => verifier.address === ecoClaim.trustedVerifier)) {
+                    const [app, userid] = subgraphVerifiedClaim.id.split(':');
+    
+                    let verifiedClaim: VerifiedClaim = {
+                        ...subgraphVerifiedClaim,
+                        app,
+                        userid,
+                        points: pts,
+                        tokenClaim: subgraphVerifiedClaim.tokenClaim ? {
+                            ...subgraphVerifiedClaim.tokenClaim,
+                            points: BigNumber.from(subgraphVerifiedClaim.tokenClaim.points),
+                            amountEco: BigNumber.from(subgraphVerifiedClaim.tokenClaim.amountEco),
+                            amountEcox: BigNumber.from(subgraphVerifiedClaim.tokenClaim.amountEcox),
+                            claimTime: BigNumber.from(subgraphVerifiedClaim.tokenClaim.claimTime),
+                        } : null,
+                        tokenRelease: subgraphVerifiedClaim.tokenRelease ? {
+                            ...subgraphVerifiedClaim.tokenRelease,
+                            claimTime: BigNumber.from(subgraphVerifiedClaim.tokenRelease.claimTime)
+                        } : null
+                    }
+                    
+                    if (verifiedClaim.tokenClaim) {
+                        if (verifiedClaim.tokenRelease) {
+                            verifiedClaim.claimState = ClaimState.FullyClaimed;
+                            fullyClaimed.push(verifiedClaim);
+                        }
+                        else {
+                            const secondClaimAvailableAt = ecoClaim.getVestingCliffs(verifiedClaim.points, verifiedClaim.tokenClaim.claimTime.toNumber())[0].availableAfter;
+                            if (Math.round(Date.now()/1000) < secondClaimAvailableAt) {
+                                verifiedClaim.claimState = ClaimState.NotReadyForSecondClaim;
+                                notReadyForSecondClaim.push(verifiedClaim);
+                            }
+                            else {
+                                verifiedClaim.claimState = ClaimState.ReadyForSecondClaim;
+                                readyForSecondClaim.push(verifiedClaim);
+                            }
+                        }
+                    }
+                    else {
+                        verifiedClaim.claimState = ClaimState.Unclaimed;
+                        unclaimed.push(verifiedClaim);
+                    }
+                    eligibleClaims.push(verifiedClaim);
+                }
+                return eligibleClaims;
+            }, []);
+            setVerifiedClaims([eligible, unclaimed, notReadyForSecondClaim, readyForSecondClaim, fullyClaimed]);
+        }
+        if (data) {
+            parseVerifiedClaims();
+            const timer = setInterval(() => parseVerifiedClaims(), 5000);
+            return () => clearInterval(timer);
+        }
+    }, [data, ecoClaim]);
 
     if (error) {
         console.log(error);
     }
-    else if (data) {
-        verifiedClaims = data.verifiedClaims.reduce((eligibleClaims: VerifiedClaim[], verifiedClaim) => {
-            // no points, not claimable
-            // not verified by the trusted verifier, not claimable
-            const pts = BigNumber.from(points[verifiedClaim.id] || 0);
-
-            if (pts.gt(0) && verifiedClaim.verifiers.find((verifier) => verifier.address === trustedVerifier)) {
-                const [app, userid] = verifiedClaim.id.split(':');
-                eligibleClaims.push({
-                    ...verifiedClaim,
-                    app,
-                    userid,
-                    points: pts,
-                    tokenClaim: verifiedClaim.tokenClaim ? {
-                        ...verifiedClaim.tokenClaim,
-                        points: BigNumber.from(verifiedClaim.tokenClaim.points),
-                        amountEco: BigNumber.from(verifiedClaim.tokenClaim.amountEco),
-                        amountEcox: BigNumber.from(verifiedClaim.tokenClaim.amountEcox),
-                        claimTime: BigNumber.from(verifiedClaim.tokenClaim.claimTime),
-                    } : null
-                })
-            }
-            return eligibleClaims;
-        }, []);
-    }
-
     return verifiedClaims;
 }
 
@@ -106,6 +172,14 @@ const VERIFIED_CLAIMS = gql`
                 amountEcox
                 recipient
                 claimTime
+            }
+            tokenRelease {
+                amountEco
+                amountEcox
+                recipient
+                claimTime
+                gasPayer
+                feeAmount
             }
         }
     }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -25,6 +25,7 @@ import { EcoClaimProvider } from "providers/EcoClaim";
 import { useState, useEffect } from "react";
 import MobileBlock from "components/MobileBlock";
 import UnsecureGate from "components/UnsecureGate";
+import Alert, { AlertContext } from "components/Alert";
 
 const client = new ApolloClient({
   uri: process.env.NEXT_PUBLIC_SUBGRAPH_URI,
@@ -55,13 +56,18 @@ function ClaimDapp({ Component, pageProps }: AppProps) {
 
   const [shouldShowHelp, setShouldShowHelp] = useState(false);
   const [shouldShowBlock, setShouldShowBlock] = useState(false);
+  const [shouldShowAlert, setShouldShowAlert] = useState(false);
+  const [alertBody, setAlertBody] = useState({
+    primaryButtonHandler: () => { },
+    secondaryButtonHandler: () => { }
+  })
 
   const [unsecure, setUnsecure] = useState(true);
   useEffect(() => {
     setUnsecure(window.self !== window.top);
   }, [])
 
-  return unsecure ? <UnsecureGate/> : (
+  return unsecure ? <UnsecureGate /> : (
     <WagmiConfig client={wagmiClient}>
       <RainbowKitProvider chains={chains}>
         <ApolloProvider client={client}>
@@ -70,37 +76,45 @@ function ClaimDapp({ Component, pageProps }: AppProps) {
               shouldShow: shouldShowHelp,
               setShouldShow: setShouldShowHelp
             }}>
-              <UIBlockContext.Provider value={{
-                shouldShow: shouldShowBlock,
-                setShouldShow: setShouldShowBlock
+              <AlertContext.Provider value={{
+                shouldShow: shouldShowAlert,
+                setShouldShow: setShouldShowAlert,
+                alertBody: alertBody,
+                setAlert: setAlertBody
               }}>
-                <Head>
-                  <title>Eco Claim</title>
-                  <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+                <UIBlockContext.Provider value={{
+                  shouldShow: shouldShowBlock,
+                  setShouldShow: setShouldShowBlock
+                }}>
+                  <Head>
+                    <title>Eco Claim</title>
+                    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
 
-                  <link rel="alternate icon" type="image/png" href="/favicon.png" />
-                  <meta name="description"
-                    content="Claim your on-chain Eco ID representing your Discord or Twitter account." />
+                    <link rel="alternate icon" type="image/png" href="/favicon.png" />
+                    <meta name="description"
+                      content="Claim your on-chain Eco ID representing your Discord or Twitter account." />
 
-                  <meta property="og:title" content="Eco Claim" />
-                  <meta property="og:type" content="website" />
-                  <meta property="og:url" content="https://claim.eco.id" />
-                  <meta property="og:image" content="/meta_image.png" />
+                    <meta property="og:title" content="Eco Claim" />
+                    <meta property="og:type" content="website" />
+                    <meta property="og:url" content="https://claim.eco.id" />
+                    <meta property="og:image" content="/meta_image.png" />
 
-                  <link rel="image_src" href="/meta_image.png" />
+                    <link rel="image_src" href="/meta_image.png" />
 
-                  <meta name="twitter:title" content="Eco Claim" />
-                  <meta name="twitter:description" content="Claim your on-chain Eco ID representing your Discord or Twitter account." />
-                  <meta name="twitter:image" content="/meta_image.png" />
-                  <meta name="twitter:card" content="summary_large_image" />
+                    <meta name="twitter:title" content="Eco Claim" />
+                    <meta name="twitter:description" content="Claim your on-chain Eco ID representing your Discord or Twitter account." />
+                    <meta name="twitter:image" content="/meta_image.png" />
+                    <meta name="twitter:card" content="summary_large_image" />
 
-                </Head>
-                <Component {...pageProps} />
-                <ToastContainer position="bottom-right" />
-                <HelpOverlay shouldShow={shouldShowHelp} />
-                <MobileBlock />
-                <UIBlock />
-              </UIBlockContext.Provider>
+                  </Head>
+                  <Component {...pageProps} />
+                  <ToastContainer position="bottom-right" />
+                  <HelpOverlay shouldShow={shouldShowHelp} />
+                  <Alert shouldShow={shouldShowAlert} alertBody={alertBody} />
+                  <MobileBlock />
+                  <UIBlock />
+                </UIBlockContext.Provider>
+              </AlertContext.Provider>
             </HelpOverlayContext.Provider>
           </EcoClaimProvider>
         </ApolloProvider>

--- a/pages/claim.tsx
+++ b/pages/claim.tsx
@@ -188,21 +188,21 @@ const Home: NextPage = () => {
         if (!selectedClaim) { return }
 
         const refreshedSelectedClaim = getClaimForUserId(selectedClaim.userid);
+        setSelectedClaim(refreshedSelectedClaim);
         // first claim
         if (refreshedSelectedClaim && refreshedSelectedClaim.tokenClaim && isAwaitingClaimConfirmation) {
-            setSelectedClaim(refreshedSelectedClaim);
+            
             setIsLoading(false);
             setIsAwaitingClaimConfirmation(false);
             toast({ title: "Claim successful!", intent: 'success' });
         }
         // second claim
         if (refreshedSelectedClaim && refreshedSelectedClaim.tokenRelease && isAwaitingReleaseConfirmation) {
-            setSelectedClaim(refreshedSelectedClaim);
             setIsLoading(false);
             setIsAwaitingReleaseConfirmation(false);
             toast({ title: "Claim successful!", intent: 'success' });
         }
-    }, [eligible, selectedClaim])
+    }, [eligible, notReadyForSecondClaim, readyForSecondClaim])
 
     useEffect(() => {
         uiBlockContext.setShouldShow(isLoading);
@@ -270,7 +270,7 @@ const Home: NextPage = () => {
                                         claim={selectedClaim} onClaimButtonClick={handleClaimButtonClick}
                                         isClaimPending={isLoading}
                                     />
-                                    {(unclaimed.length + readyForSecondClaim.length) > 0 &&
+                                    {([...unclaimed, ...readyForSecondClaim].filter(claim => !(claim.app === selectedClaim.app && claim.userid === selectedClaim.userid)).length) > 0 &&
                                         <div>
                                             <Button small title="You have another claim" secondary showArrow onClick={() => { setSelectedClaim(null) }} />
                                         </div>

--- a/pages/claim.tsx
+++ b/pages/claim.tsx
@@ -16,7 +16,7 @@ import Layout from "components/layout";
 import LoggedOut from "components/loggedOut";
 import Projection from "components/Projection";
 import VStack from "components/vstack";
-import { useVerifiedClaims, VerifiedClaim } from "hooks/VerifiedClaims";
+import { ClaimState, useVerifiedClaims, VerifiedClaim } from "hooks/VerifiedClaims";
 import { useEcoClaim } from "providers/EcoClaim";
 import EcoClaim from "../assets/abi/EcoClaim.json";
 import useMerkleTree from "../hooks/MerkleTree";
@@ -28,6 +28,8 @@ import ClaimDetailsHeaderUnclaimed from "components/ClaimDetailsHeaderUnclaimed"
 import { UIBlockContext } from "components/UIBlock";
 import styles from "css/modules/home.module.scss";
 import { txError, toast } from "utilities";
+import { AlertContext } from "components/Alert";
+import Pill from "components/Pill";
 
 export const shortAddress = (address: string) => {
     if (!address) { return "" }
@@ -41,18 +43,43 @@ const Home: NextPage = () => {
     const [isConnected, setIsConnected] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [isAwaitingClaimConfirmation, setIsAwaitingClaimConfirmation] = useState(false);
+    const [isAwaitingReleaseConfirmation, setIsAwaitingReleaseConfirmation] = useState(false);
     const [selectedClaim, setSelectedClaim] = useState<VerifiedClaim>(null);
+    const [isFullyVested, setIsFullyVested] = useState(false);
 
     const ecoClaim = useEcoClaim();
-    const verifiedClaims = useVerifiedClaims(address, ecoClaim.trustedVerifier);
-
-    const unclaimed = verifiedClaims.filter(verifiedClaim => !verifiedClaim.tokenClaim);
-    const claimed = verifiedClaims.filter(verifiedClaim => verifiedClaim.tokenClaim)
+    const [eligible, unclaimed, notReadyForSecondClaim, readyForSecondClaim, fullyClaimed] = useVerifiedClaims(address);
 
     // ask to connect wallet, or if wallet is connected, get data on registrations and mints
     const { leaves } = useMerkleTree();
 
     const uiBlockContext = useContext(UIBlockContext);
+    const alertContext = useContext(AlertContext);
+
+    useEffect(() => {
+        const getCurrentCliff = () => {
+            const currTime = Math.round(Date.now() / 1000);
+
+            const vestingCliffs = ecoClaim.getVestingCliffs(selectedClaim.points, selectedClaim.tokenClaim.claimTime.toNumber());
+            // reduce to only the upticks in amount
+            const cliffs = [vestingCliffs[0], vestingCliffs[5], vestingCliffs[17], vestingCliffs[23]];
+
+            // find the earliest cliff that hasn't been reached yet
+            const index = cliffs.findIndex((cliff) => cliff.availableAfter > currTime)
+
+            if (index === -1) {
+                // no such index? all cliffs have passed
+                setIsFullyVested(true);
+            } else {
+                setIsFullyVested(index >= cliffs.length);
+            }
+        }
+
+        if (selectedClaim && selectedClaim.tokenClaim) {
+            getCurrentCliff();
+        }
+
+    }, [selectedClaim, ecoClaim]);
 
     const claim = async ({ app, userid, points }: VerifiedClaim) => {
         setIsLoading(true);
@@ -106,8 +133,38 @@ const Home: NextPage = () => {
         }
     };
 
+    // aka second claim
+    const release = async ({ app, userid }) => {
+        setIsLoading(true);
+        try {
+
+            const claimContract = new ethers.Contract(
+                ecoClaim.address,
+                EcoClaim.abi,
+                signer!
+            );
+
+            const claimTx = await claimContract.releaseTokens(`${app}:${userid}`,
+                { gasLimit: 500_000 }
+            );
+
+            const claimReceipt = await claimTx.wait();
+
+            if (!claimReceipt.status) {
+                setIsLoading(false);
+                throw new Error(claimTx);
+            } else {
+                setIsAwaitingReleaseConfirmation(true);
+            }
+        } catch (err) {
+            setIsLoading(false);
+            txError("Claim failed", err)
+            console.log(err);
+        }
+    }
+
     const getClaimForUserId = (userId: string): VerifiedClaim => {
-        for (let claim of verifiedClaims) {
+        for (let claim of eligible) {
             if (claim.userid === userId) {
                 return claim;
             }
@@ -122,7 +179,7 @@ const Home: NextPage = () => {
     }, [address])
 
     useEffect(() => {
-        if (verifiedClaims.length === 1 && !selectedClaim) {
+        if (eligible.length === 1 && !selectedClaim) {
             setSelectedClaim(unclaimed[0])
         }
     }, [unclaimed])
@@ -131,14 +188,21 @@ const Home: NextPage = () => {
         if (!selectedClaim) { return }
 
         const refreshedSelectedClaim = getClaimForUserId(selectedClaim.userid);
-
+        // first claim
         if (refreshedSelectedClaim && refreshedSelectedClaim.tokenClaim && isAwaitingClaimConfirmation) {
             setSelectedClaim(refreshedSelectedClaim);
             setIsLoading(false);
             setIsAwaitingClaimConfirmation(false);
-            toast({title: "Claim successful!", intent: 'success'});
+            toast({ title: "Claim successful!", intent: 'success' });
         }
-    }, [verifiedClaims, selectedClaim])
+        // second claim
+        if (refreshedSelectedClaim && refreshedSelectedClaim.tokenRelease && isAwaitingReleaseConfirmation) {
+            setSelectedClaim(refreshedSelectedClaim);
+            setIsLoading(false);
+            setIsAwaitingReleaseConfirmation(false);
+            toast({ title: "Claim successful!", intent: 'success' });
+        }
+    }, [eligible, selectedClaim])
 
     useEffect(() => {
         uiBlockContext.setShouldShow(isLoading);
@@ -154,7 +218,25 @@ const Home: NextPage = () => {
     }
 
     const handleClaimButtonClick = () => {
-        claim(selectedClaim);
+        if (!selectedClaim.tokenClaim) {
+            claim(selectedClaim);
+        }
+        else {
+            if (!isFullyVested) {
+                alertContext.setAlert({
+                    primaryButtonHandler: () => {
+                        alertContext.setShouldShow(false);
+                    },
+                    secondaryButtonHandler: () => {
+                        alertContext.setShouldShow(false);
+                        release(selectedClaim);
+                    }
+                })
+                alertContext.setShouldShow(true);
+            } else {
+                release(selectedClaim);
+            }
+        }
     }
 
     return (
@@ -169,14 +251,14 @@ const Home: NextPage = () => {
                             {selectedClaim ?
                                 <>
                                     {selectedClaim.tokenClaim ?
-                                        <ClaimDetailsHeaderClaimed onBackButtonClick={() => { setSelectedClaim(null) }} verifiedClaims={verifiedClaims} selectedClaim={selectedClaim} />
+                                        <ClaimDetailsHeaderClaimed onBackButtonClick={() => { setSelectedClaim(null) }} eligibleClaims={eligible} selectedClaim={selectedClaim} />
                                         :
                                         <>
-                                            <ClaimDetailsHeaderUnclaimed onBackButtonClick={() => { setSelectedClaim(null) }} verifiedClaims={verifiedClaims} selectedClaim={selectedClaim} />
+                                            <ClaimDetailsHeaderUnclaimed onBackButtonClick={() => { setSelectedClaim(null) }} eligibleClaims={eligible} selectedClaim={selectedClaim} />
                                             <ClaimDetails
                                                 claimingEndsAt={ecoClaim.claimingEndsAt}
                                                 claim={selectedClaim}
-                                                hasAdditionalClaims={verifiedClaims.length > 1}
+                                                hasAdditionalClaims={eligible.length > 1}
                                                 onClaimButtonClick={handleClaimButtonClick}
                                                 isClaimPending={isLoading}
                                                 handleChangeButtonClick={() => { setSelectedClaim(null) }}
@@ -184,11 +266,14 @@ const Home: NextPage = () => {
                                         </>
                                     }
                                     <div />
-                                    <Projection claim={selectedClaim} />
+                                    <Projection
+                                        claim={selectedClaim} onClaimButtonClick={handleClaimButtonClick}
+                                        isClaimPending={isLoading}
+                                    />
                                 </>
                                 :
                                 <>
-                                    {verifiedClaims.length === 0 ?
+                                    {eligible.length === 0 ?
                                         <Copy>
                                             <p className="text-size-xlarge text-color-normal font-romana">
                                                 <span className="text-color-medium">Welcome <strong>{shortAddress(address)}</strong>,</span>
@@ -207,25 +292,45 @@ const Home: NextPage = () => {
                                         </Copy>
                                     }
 
+                                    {readyForSecondClaim.length > 0 &&
+                                        <VStack>
+                                            <p className="sectionSubtitle">Ready to redeem second claim</p>
+                                            {readyForSecondClaim.map(claim => {
+                                                return <ClaimButton key={claim.userid} claim={claim} onButtonClick={(_) => { setSelectedClaim(claim) }} actionAvailable={false} />
+                                            })}
+                                        </VStack>
+
+                                    }
                                     {unclaimed.length > 0 &&
                                         <VStack>
-                                            <p className="sectionSubtitle">Ready to redeem</p>
+                                            <p className="sectionSubtitle">Ready to redeem first claim</p>
                                             {unclaimed.map(claim => {
-                                                return <ClaimButton key={claim.userid} claim={claim} onButtonClick={(_) => { setSelectedClaim(claim) }} isClaimed={false} />
+                                                return <ClaimButton key={claim.userid} claim={claim} onButtonClick={(_) => { setSelectedClaim(claim) }} actionAvailable={false} />
                                             })}
                                         </VStack>
 
                                     }
 
-                                    {claimed.length > 0 &&
+                                    {notReadyForSecondClaim.length > 0 &&
                                         <VStack>
-                                            <p className="sectionSubtitle">Previously redeemed</p>
-                                            {claimed.map(claim => {
-                                                return <ClaimButton key={claim.userid} claim={claim} onButtonClick={() => { }} isClaimed />
+                                            <p className="sectionSubtitle">Awaiting second redeem</p>
+                                            {notReadyForSecondClaim.map(claim => {
+                                                return <ClaimButton key={claim.userid} claim={claim} onButtonClick={(_) => { }} actionAvailable />
                                             })}
                                         </VStack>
 
                                     }
+                                    {fullyClaimed.length > 0 &&
+                                        <VStack>
+                                            <p className="sectionSubtitle">Fully redeemed</p>
+                                            {fullyClaimed.map(claim => {
+                                                return <ClaimButton key={claim.userid} claim={claim} onButtonClick={() => { }} actionAvailable />
+                                            })}
+                                        </VStack>
+
+                                    }
+
+
                                 </>
 
                             }
@@ -242,16 +347,18 @@ const Home: NextPage = () => {
 type ClaimButtonProps = {
     claim: VerifiedClaim;
     onButtonClick: (id: string) => void;
-    isClaimed: boolean;
+    actionAvailable: boolean;
 }
 
-const ClaimButton = ({ claim, isClaimed, onButtonClick }: ClaimButtonProps) => {
+const ClaimButton = ({ claim, actionAvailable, onButtonClick }: ClaimButtonProps) => {
+
+    const ecoClaim = useEcoClaim();
 
     const getDate = (claimTime: BigNumber) => {
         return new Date(claimTime.toNumber() * 1000).toLocaleDateString('en-US');
     }
 
-    return <div className={classNames(styles.claimButton, isClaimed ? styles.isClaimed : undefined)} key={claim.userid}>
+    return <div className={classNames(styles.claimButton, actionAvailable ? styles.actionAvailable : undefined)} key={claim.userid}>
         <HStack gapSize={StackGapSize.Large}>
             <div className={styles.icon}>
                 {claim.app === "twitter" &&
@@ -270,19 +377,29 @@ const ClaimButton = ({ claim, isClaimed, onButtonClick }: ClaimButtonProps) => {
             </div>
             <VStack gapSize={StackGapSize.Small}>
                 <strong>{upperFirst(claim.app)}</strong>
-                <VStack gapSize={StackGapSize.None}>
+                <VStack gapSize={StackGapSize.Small}>
                     <span className="text-size-small text-color-medium">ID: {claim.userid}</span>
-                    {isClaimed && <p className="text-size-small">Redeemed on: {getDate(claim.tokenClaim.claimTime)}</p>}
+                    {claim.claimState > ClaimState.Unclaimed && (
+                        <HStack gapSize={StackGapSize.Small}>
+                            <Pill><>1st claim • {getDate(claim.tokenClaim.claimTime)}</></Pill>
+                            <span className="text-size-small text-color-medium">{utils.formatUnits(claim.tokenClaim.amountEco)} ECO • {utils.formatUnits(claim.tokenClaim.amountEcox)} ECOx</span>
+                        </HStack>
+                    )}
+                    {claim.claimState === ClaimState.FullyClaimed ? (
+                        <HStack gapSize={StackGapSize.Small}>
+                            <Pill><>2nd claim • {getDate(claim.tokenRelease.claimTime)}</></Pill>
+                            <span className="text-size-small text-color-medium">{utils.formatUnits(claim.tokenRelease.amountEco)} ECO • {utils.formatUnits(claim.tokenRelease.amountEcox)} ECOx</span>
+                        </HStack>
+                    ) : claim.claimState > ClaimState.Unclaimed ? (
+                        <HStack gapSize={StackGapSize.Small}>
+                            <Pill><>2nd claim</></Pill>
+                            <span className="text-size-small text-color-medium">Eligible {getDate(BigNumber.from(ecoClaim.getVestingCliffs(claim.points, claim.tokenClaim.claimTime.toNumber())[0].availableAfter))}</span>
+                        </HStack>
+                    ) : null}
                 </VStack>
             </VStack>
         </HStack>
-        {!isClaimed && <Button showArrow title="Select" onClick={onButtonClick.bind(this, claim.userid)} />}
-        {isClaimed &&
-            <VStack gapSize={StackGapSize.None}>
-                <p className="text-size-small"><strong className="text-color-normal">{utils.formatUnits(claim.tokenClaim.amountEco)}</strong> ECO</p>
-                <p className="text-size-small"><strong className="text-color-normal">{utils.formatUnits(claim.tokenClaim.amountEcox)}</strong> ECOx</p>
-            </VStack>
-        }
+        {!actionAvailable && <Button showArrow title="Select" onClick={onButtonClick.bind(this, claim.userid)} />}
     </div>
 };
 

--- a/pages/claim.tsx
+++ b/pages/claim.tsx
@@ -270,6 +270,11 @@ const Home: NextPage = () => {
                                         claim={selectedClaim} onClaimButtonClick={handleClaimButtonClick}
                                         isClaimPending={isLoading}
                                     />
+                                    {(unclaimed.length + readyForSecondClaim.length) > 0 &&
+                                        <div>
+                                            <Button small title="You have another claim" secondary showArrow onClick={() => { setSelectedClaim(null) }} />
+                                        </div>
+                                    }
                                 </>
                                 :
                                 <>
@@ -329,12 +334,8 @@ const Home: NextPage = () => {
                                         </VStack>
 
                                     }
-
-
                                 </>
-
                             }
-
                         </VStack>
                     }
                 </div>

--- a/pages/claim.tsx
+++ b/pages/claim.tsx
@@ -210,10 +210,11 @@ const Home: NextPage = () => {
 
 
     const getClaimCount = () => {
-        if (unclaimed.length === 1) {
+        const length = unclaimed.length + readyForSecondClaim.length;
+        if (length === 1) {
             return "1 claim";
         } else {
-            return `${unclaimed.length} claims`;
+            return `${length} claims`;
         }
     }
 


### PR DESCRIPTION
Added state and function for making second claim (aka releases)
- Transitioned mentions of 'Claim' to 'First Claim'
- Changed default view to show 4 different claim state lists (unclaimed, first claim and not ready for second, ready for second claim, fully claimed)
- Edited `Projection` component to show live tracking of second claim cliff after first claim is complete
- Added 1st and 2nd claim status/eligibility to list items
- Added modal warning if your second claim is not at the maximum amount redeemable yet